### PR TITLE
Remove functions broken by new file system

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -210,7 +210,13 @@ def collector(compression, directory, version, license):
         # Change into home directory and gather info about environment
         output_dir = os.getcwd()
         os.chdir(home_env_var)
-        commands = ["check_aci_storage_quota", "ls -lha", "du -h --max-depth=1", "env"]
+
+        # Original block, commented out until check_aci_storage_quota script is to have a known
+        # fix on the Roar system.
+        # commands = ["check_aci_storage_quota", "ls -lha", "du -h --max-depth=1", "env"]
+
+        # New block until check_aci_storage_quota is fixed on Roar.
+        commands = ["ls -lha", "du -h --max-depth=1", "env"]
 
         bar = Bar("Collecting info on environment", max=len(commands))
         for command in commands:

--- a/gathero.py
+++ b/gathero.py
@@ -162,11 +162,13 @@ def gathero(job, name, compression, directory, version, license):
         if len(user_id) != 0:
             for user in user_id:
                 fout = open("{}-info.txt".format(user), "wt")
-                # Run account_quota_check
-                account_quota_check = subprocess.run(["account_quota_check", "{}".format(user)], 
-                                                        capture_output=True, text=True)
-                fout.write("account_quota_check {}\n".format(user))
-                fout.write(str(account_quota_check.stdout) + "\n\n")
+                # Block is commented out until account_quota_check is confirmed to
+                # be fixed on the Roar system.
+                # # Run account_quota_check
+                # account_quota_check = subprocess.run(["account_quota_check", "{}".format(user)], 
+                #                                         capture_output=True, text=True)
+                # fout.write("account_quota_check {}\n".format(user))
+                # fout.write(str(account_quota_check.stdout) + "\n\n")
 
                 # Run qstat
                 qstat = subprocess.run(["qstat", "-u", "{}".format(user)], 


### PR DESCRIPTION
The newest update broke the `account_quota_check` and `check_aci_storage_quota` scripts used by some of the Python scripts in this collection. As such, I have updated iaskutils to no longer use these specific scripts until they are confirmed to be fixed.